### PR TITLE
some adaptations for embeddin into c++ code

### DIFF
--- a/tib/io.c
+++ b/tib/io.c
@@ -108,7 +108,7 @@ prim_save(Tsp st, Hash env, Val args)
 	fname = cadr(args)->v.s;
 	if (!(f = fopen(fname, "wb")))
 		tsp_warnf("save: could not load file '%s'", fname);
-	if (!(fwrite(&*car(args), sizeof(struct Val), 1, f))) {
+	if (!(fwrite(&*car(args), sizeof(struct Val_), 1, f))) {
 		fclose(f);
 		tsp_warnf("save: could not save file '%s'", fname);
 	}
@@ -122,18 +122,18 @@ prim_open(Tsp st, Hash env, Val args)
 {
 	FILE *f;
 	char *fname;
-	struct Val v;
+	struct Val_ v;
 	Val ret;
-	if (!(ret = malloc(sizeof(struct Val))))
+	if (!(ret = malloc(sizeof(struct Val_))))
 		perror("; malloc"), exit(1);
 	tsp_arg_min(args, "open", 1);
 	tsp_arg_type(car(args), "open", TSP_STR);
 	fname = car(args)->v.s;
 	if (!(f = fopen(fname, "rb")))
 		tsp_warnf("save: could not load file '%s'", fname);
-	while (fread(&v, sizeof(struct Val), 1, f)) ;
+	while (fread(&v, sizeof(struct Val_), 1, f)) ;
 	fclose(f);
-	memcpy(ret, &v, sizeof(struct Val));
+	memcpy(ret, &v, sizeof(struct Val_));
 	return ret;
 }
 

--- a/tisp.c
+++ b/tisp.c
@@ -183,11 +183,11 @@ static Hash
 hash_new(size_t cap, Hash next)
 {
 	if (cap < 1) return NULL;
-	Hash ht = malloc(sizeof(struct Hash));
+	Hash ht = malloc(sizeof(struct Hash_));
 	if (!ht) perror("; malloc"), exit(1);
 	ht->size = 0;
 	ht->cap = cap;
-	ht->items = calloc(cap, sizeof(struct Entry));
+	ht->items = calloc(cap, sizeof(struct Entry_));
 	if (!ht->items) perror("; calloc"), exit(1);
 	ht->next = next;
 	return ht;
@@ -228,7 +228,7 @@ hash_grow(Hash ht)
 	int i, ocap = ht->cap;
 	Entry oitems = ht->items;
 	ht->cap *= 2;
-	ht->items = calloc(ht->cap, sizeof(struct Entry));
+	ht->items = calloc(ht->cap, sizeof(struct Entry_));
 	if (!ht->items) perror("; calloc"), exit(1);
 	for (i = 0; i < ocap; i++) /* repopulate new hash table with old values */
 		if (oitems[i].key)
@@ -280,7 +280,7 @@ hash_extend(Hash ht, Val args, Val vals)
 Val
 mk_val(TspType t)
 {
-	Val ret = malloc(sizeof(struct Val));
+	Val ret = malloc(sizeof(struct Val_));
 	if (!ret) perror("; malloc"), exit(1);
 	ret->t = t;
 	return ret;
@@ -1082,7 +1082,7 @@ tisp_env_add(Tsp st, char *key, Val v)
 Tsp
 tisp_env_init(size_t cap)
 {
-	Tsp st = malloc(sizeof(struct Tsp));
+	Tsp st = malloc(sizeof(struct Tsp_));
 	if (!st) perror("; malloc"), exit(1);
 
 	st->file = NULL;

--- a/tisp.h
+++ b/tisp.h
@@ -18,6 +18,11 @@
  *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
+#ifndef TISP_H
+#define TISP_H
+
+#include <stdlib.h>
+#include <stdio.h>
 
 #define tsp_warnf(M, ...) do {                                  \
 	fprintf(stderr, "; tisp: error: " M "\n", ##__VA_ARGS__); \
@@ -70,19 +75,19 @@
 #define num(P)  ((P)->v.n.num)
 #define den(P)  ((P)->v.n.den)
 
-struct Val;
-typedef struct Val *Val;
-typedef struct Tsp *Tsp;
+struct Val_;
+typedef struct Val_ *Val;
+typedef struct Tsp_ *Tsp;
 
-typedef struct Entry *Entry;
+typedef struct Entry_ *Entry;
 
-typedef struct Hash {
+typedef struct Hash_ {
 	int size, cap;
-	struct Entry {
+	struct Entry_ {
 		char *key;
 		Val val;
 	} *items;
-	struct Hash *next;
+	struct Hash_ *next;
 } *Hash;
 
 /* possible tisp object types */
@@ -109,7 +114,7 @@ typedef enum {
 typedef Val (*Prim)(Tsp, Hash, Val);
 
 /* tisp object */
-struct Val {
+struct Val_ {
 	TspType t; /* NONE, NIL */
 	union {
 		char *s;                                            /* STRING, SYMBOL */
@@ -121,7 +126,7 @@ struct Val {
 };
 
 /* tisp state and global environment */
-struct Tsp {
+struct Tsp_ {
 	char *file;
 	size_t filec;
 	Val none, nil, t;
@@ -156,3 +161,5 @@ Val tisp_parse_file(Tsp st, char *fname);
 void tisp_env_add(Tsp st, char *key, Val v);
 Tsp  tisp_env_init(size_t cap);
 void tisp_env_lib(Tsp st, char* lib);
+
+#endif // TISP_H


### PR DESCRIPTION
Hey,

After trying to embedding tisp into c++ code I got warnings of kind:
```
tisp.h:75:21: error: conflicting declaration ‘typedef struct Tsp* Tsp’
   75 | typedef struct Tsp *Tsp;
      |                     ^~~
tisp.h:75:16: note: previous declaration as ‘struct Tsp’
   75 | typedef struct Tsp *Tsp;
```
reason is the reuse of the structure name as type name. 

After that changes embedding was possible...